### PR TITLE
feat: Added patient-browser

### DIFF
--- a/paradire/hapi_fhir_patch/docker-compose.yml
+++ b/paradire/hapi_fhir_patch/docker-compose.yml
@@ -7,6 +7,10 @@ services:
     restart: on-failure
     ports:
       - "8080:8080"
+    configs:
+      - source: hapi
+        target: /app/config/application.yaml
+
   hapi-fhir-postgres:
     image: postgres:13-alpine
     container_name: hapi-fhir-postgres

--- a/paradire/hapi_fhir_patch/hapi.application.yaml
+++ b/paradire/hapi_fhir_patch/hapi.application.yaml
@@ -14,12 +14,16 @@ spring:
     check-location: false
     baselineOnMigrate: true
   datasource:
-    url: 'jdbc:h2:file:./target/database/h2'
+    # url: 'jdbc:h2:file:./target/database/h2'
     #url: jdbc:h2:mem:test_mem
-    username: sa
-    password: null
-    driverClassName: org.h2.Driver
-    max-active: 15
+    # username: sa
+    # password: null
+    # driverClassName: org.h2.Driver
+    url: 'jdbc:postgresql://hapi-fhir-postgres:5432/hapi'
+    username: admin
+    password: admin
+    driverClassName: org.postgresql.Driver    
+    # max-active: 15
 
     # database connection pool size
     hikari:
@@ -28,11 +32,13 @@ spring:
     properties:
       hibernate.format_sql: false
       hibernate.show_sql: false
+      hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
+      hibernate.search.enabled: false
 
       #Hibernate dialect is automatically detected except Postgres and H2.
       #If using H2, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
       #If using postgres, then supply the value of ca.uhn.fhir.jpa.model.dialect.HapiFhirPostgres94Dialect
-      hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
+      # hibernate.dialect: ca.uhn.fhir.jpa.model.dialect.HapiFhirH2Dialect
   #      hibernate.hbm2ddl.auto: update
   #      hibernate.jdbc.batch_size: 20
   #      hibernate.cache.use_query_cache: false
@@ -41,7 +47,7 @@ spring:
   #      hibernate.cache.use_minimal_puts: false
 
   ###    These settings will enable fulltext search with lucene or elastic
-      hibernate.search.enabled: true
+      # hibernate.search.enabled: true
   ### lucene parameters
 #      hibernate.search.backend.type: lucene
 #      hibernate.search.backend.analysis.configurer: ca.uhn.fhir.jpa.search.HapiHSearchAnalysisConfigurers$HapiLuceneAnalysisConfigurer

--- a/paradire/setup_patient_browser.sh
+++ b/paradire/setup_patient_browser.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+# Note, FHIR server must be running and available on localhost:8080 prior to running
+# this script.
+
+curr_dir=$(pwd)
+
+cd 
+
+if [ ! -d "patient-browser" ]; then
+    git clone https://github.com/smart-on-fhir/patient-browser.git
+    ## Install dependencies and build project
+    (cd patient-browser && NODE_ENV=production npm ci)
+fi
+
+cd patient-browser
+
+# Configure browser
+rm -f ./build/config/*.json5
+mkdir ./config
+echo "Generating config, please wait..."
+node config-genrator/generate_config.js -s http://127.0.0.1:8080/fhir -f default
+mv config/default.json5 ./build/config/
+rm -rf ./config
+
+# Build docker image
+docker build . -t patient-browser
+
+# Start browser
+docker run -d --restart always --name patient-browser -p 9090:80  patient-browser 
+
+echo "Patient browser started on http://localhost:9090"
+
+cd $curr_dir


### PR DESCRIPTION

Added patient-browser setup script, available on http://localhost:9090 via docker.

** may require installation of node - did not add that.

Performance of FIHR server was extremely slow, setup pgsql as backen.d.

** also disabled full text search as per the example documentation
